### PR TITLE
Sleep for 10s before starting replay

### DIFF
--- a/plugin.cpp
+++ b/plugin.cpp
@@ -58,6 +58,7 @@ LRESULT CALLBACK window_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (wParam == PBT_APMRESUMEAUTOMATIC) {
             //Is this thread safe? Who knows lol
             if (replay_active_on_suspend)
+                Sleep(10000);
                 start_replay();
 
         } else if (wParam == PBT_APMSUSPEND) {


### PR DESCRIPTION
I am using a networked drive to store OBS replays however when Windows has been sleeping for long periods of time it will not have a network connection for a few seconds after it wakes up. This causes an error when starting the replay that the drive doesn't exist. After using this version for a few days on 10s sleep timer I have yet to see the error again so it appears to be working for me.

I wasn't sure how to actually compile this so I created a separate repo using the OBS plugin template to use GitHub Actions to compile it here if anyone wants to try it: https://github.com/Jefemy/obs-plugin-test/tree/master